### PR TITLE
Add Markdown Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # MINI
 
-MINI is a simple CLI for generating HTML page(s) from text file(s).
+MINI is a simple CLI for generating HTML page(s) from text and markdown file(s).
 
 ## Features:
 
--   Automatically parse title from input. (A title is defined by being the first line followed by 2 blank lines)
--   All generated HTML files will be placed into a `./dist` folder
--   All generated HTML files comes with [Water.css](https://github.com/kognise/water.css) by default.
--   Users can specify a URL to a CSS stylesheet.
+- Automatically parse title from input. (A title is defined by being the first line followed by 2 blank lines)
+- All generated HTML files will be placed into a `./dist` folder
+- All generated HTML files comes with [Water.css](https://github.com/kognise/water.css) by default.
+- Users can specify a URL to a CSS stylesheet.
+- If user's input is a markdown file, it will convert all Heading1, Heading2 and Link into its corresponding HTML tags
 
 ## Installation:
 
@@ -19,16 +20,25 @@ MINI is a simple CLI for generating HTML page(s) from text file(s).
 ## Usage:
 
 1. Converting a single text file:
+
 ```
 node mini-ssg.js -i ./someFolder/file.txt
 ```
 
-2. Converting a folder/directory with multiple text files:
+2. Converting a single markdown file:
+
+```
+node mini-ssg.js -i ./someFolder/file.md
+```
+
+3. Converting a folder/directory with multiple text files:
+
 ```
 node mini-ssg.js -i ./someFolder
 ```
 
-3. Converting a single text file with a specified CSS stylesheet:
+4. Converting a single text file with a specified CSS stylesheet:
+
 ```
 node mini-ssg.js -i ./file.txt -s ./stylesheetURL
 ```
@@ -37,12 +47,12 @@ You can give MINI a try and see how it works using the included `Sherlock-Holmes
 
 ## Options:
 
-| Options            | Functions                                 |
-| ------------------ | ----------------------------------------- |
-| -v or --version    | Prints the current version                |
-| -h or --help       | Prints a list of options to the screen    |
-| -i or --input [required]      | Accepts a path to either a file or folder |
-| -s or --stylesheet | Accepts a URL to a CSS stylesheet         |
+| Options                  | Functions                                 |
+| ------------------------ | ----------------------------------------- |
+| -v or --version          | Prints the current version                |
+| -h or --help             | Prints a list of options to the screen    |
+| -i or --input [required] | Accepts a path to either a file or folder |
+| -s or --stylesheet       | Accepts a URL to a CSS stylesheet         |
 
 ## Example:
 
@@ -67,26 +77,79 @@ will be converted to
 ```html
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
-    <head>
-        <title>Silver Blaze</title>
-        <meta charset="utf-8" />
+  <head>
+    <title>Silver Blaze</title>
+    <meta charset="utf-8" />
 
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link
-            rel="stylesheet"
-            href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
-        />
-    </head>
-    <body>
-        <h1>Silver Blaze</h1>
-        <p>
-            I am afraid, Watson, that I shall have to go,” said Holmes, as we
-            sat down together to our breakfast one morning.
-        </p>
-        <p>“Go! Where to?”</p>
-        <p>“To Dartmoor; to King’s Pyland.”</p>
-    </body>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
+    />
+  </head>
+  <body>
+    <h1>Silver Blaze</h1>
+    <p>
+      I am afraid, Watson, that I shall have to go,” said Holmes, as we sat down
+      together to our breakfast one morning.
+    </p>
+    <p>“Go! Where to?”</p>
+    <p>“To Dartmoor; to King’s Pyland.”</p>
+  </body>
+</html>
+```
+
+#### file.md
+
+```
+# MINI
+
+MINI is a simple CLI for generating HTML page(s) from text and markdown file(s).
+
+## Features:
+
+-   Automatically parse title from input. (A title is defined by being the first line followed by 2 blank lines)
+-   All generated HTML files will be placed into a `./dist` folder
+-   All generated HTML files comes with [Water.css](https://github.com/kognise/water.css) by default.
+-   Users can specify a URL to a CSS stylesheet.
+```
+
+will be converted to
+
+```html
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <title>file</title>
+    <meta charset="utf-8" />
+
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
+    />
+  </head>
+  <body>
+    <h1>MINI</h1>
+
+    <p>
+      MINI is a simple CLI for generating HTML page(s) from text and markdown
+      file(s).
+    </p>
+
+    <h2>Features:</h2>
+
+    <p>
+      - Automatically parse title from input. (A title is defined by being the
+      first line followed by 2 blank lines) - All generated HTML files will be
+      placed into a `./dist` folder - All generated HTML files comes with
+      <a href="https://github.com/kognise/water.css">Water.css</a> by default. -
+      Users can specify a URL to a CSS stylesheet.
+    </p>
+
+  </body>
 </html>
 ```
 

--- a/utils/generateHTML.js
+++ b/utils/generateHTML.js
@@ -1,7 +1,7 @@
 const { readFile, writeFile } = require("fs/promises");
 const path = require("path");
 const createHtml = require("create-html");
-var htmlBody = "";
+let htmlBody = "";
 
 /**
  * Generates a new html file to a 'dist' directory.
@@ -42,9 +42,9 @@ async function generateHTMLFile(inputPath, stylesheetURL) {
         .replace(/(?<!!)\[(.*?)\]\((.*?)\)/gim, "<a href='$2'>$1</a>") // replaces link -> <a href="$2">$1</a>
         .split(/\r?\n\r?\n/)
         .map(function (para) {
-          if (para.match(/(?<!#)#{1}\s/)) {
+          if (para.match(/(?<!#)#{1}\s/) != null) {
             return `<h1>${para.replace(/# /, "")}</h1>\n\n`; // replaces # -> <h1></h1>
-          } else if (para.match(/(?<!#)#{2}\s/)) {
+          } else if (para.match(/(?<!#)#{2}\s/) != null) {
             return `<h2>${para.replace(/## /, "")}</h2>\n\n`; // replace ## -> <h2></h2>
           }
           return `<p>${para.replace(/\r?\n/, " ")}</p>\n\n`;

--- a/utils/generateHTML.js
+++ b/utils/generateHTML.js
@@ -39,7 +39,7 @@ async function generateHTMLFile(inputPath, stylesheetURL) {
     } else {
       //  handles ".md" content
       htmlBody = data
-        .replace(/\[(.*?)\]\((.*?)\)/gim, "<a href='$2'>$1</a>") // replaces link -> <a href="$2">$1</a>
+        .replace(/(?<!!)\[(.*?)\]\((.*?)\)/gim, "<a href='$2'>$1</a>") // replaces link -> <a href="$2">$1</a>
         .split(/\r?\n\r?\n/)
         .map(function (para) {
           if (para.match(/(?<!#)#{1}\s/)) {

--- a/utils/generateHTML.js
+++ b/utils/generateHTML.js
@@ -1,6 +1,7 @@
 const { readFile, writeFile } = require("fs/promises");
 const path = require("path");
 const createHtml = require("create-html");
+var htmlBody = "";
 
 /**
  * Generates a new html file to a 'dist' directory.
@@ -8,51 +9,69 @@ const createHtml = require("create-html");
  * @param {string} stylesheetURL - A URL to a CSS stylesheet
  */
 async function generateHTMLFile(inputPath, stylesheetURL) {
-    try {
-        const filename = path.parse(inputPath).name;
-        const data = await readFile(inputPath, "utf-8");
+  try {
+    const filename = path.parse(inputPath).name;
+    const data = await readFile(inputPath, "utf-8");
 
-        // Retrieves HTML title (if any) - title is identified by being the first line of text followed by 2 blank lines.
-        const htmlTitle = data.match(/^.+(\r?\n\r?\n\r?\n)/);
-        // If there is an HTML title, wraps the title's content inside an <h1> tag.
-        const htmlBody =
-            htmlTitle == null
-                ? data
-                      .split(/\r?\n\r?\n/)
-                      .map((para) => {
-                          return `<p>${para.replace(/\r?\n/, " ")}</p>`;
-                      })
-                      .join(" ")
-                : `<h1>${htmlTitle[0].trim()}</h1> `.concat(
-                      data
-                          .substring(htmlTitle[0].length)
-                          .split(/\r?\n\r?\n/)
-                          .map((para) => {
-                              return `<p>${para.replace(/\r?\n/, " ")}</p>`;
-                          })
-                          .join(" ")
-                  );
+    // Retrieves HTML title (if any) - title is identified by being the first line of text followed by 2 blank lines.
+    const htmlTitle = data.match(/^.+(\r?\n\r?\n\r?\n)/);
+    // If there is an HTML title, wraps the title's content inside an <h1> tag.
 
-        const html = createHtml({
-            lang: "en",
-            head: `<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />`,
-            title: htmlTitle ? htmlTitle[0].trim() : filename,
-            css:
-                stylesheetURL != null
-                    ? stylesheetURL
-                    : "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css",
-            body: htmlBody,
-        });
-
-        await writeFile(
-            path.join(__dirname, "../", "dist", `${filename}.html`),
-            html
-        );
-        console.log(`${filename}.html has been created.`);
-    } catch (err) {
-        console.log(err);
+    if (path.extname(inputPath) === ".txt") {
+      // handles ".txt" content
+      htmlBody =
+        htmlTitle == null
+          ? data
+              .split(/\r?\n\r?\n/)
+              .map((para) => {
+                return `<p>${para.replace(/\r?\n/, " ")}</p>\n\n`;
+              })
+              .join(" ")
+          : `<h1>${htmlTitle[0].trim()}</h1>\n\n`.concat(
+              data
+                .substring(htmlTitle[0].length)
+                .split(/\r?\n\r?\n/)
+                .map((para) => {
+                  return `<p>${para.replace(/\r?\n/, " ")}</p>\n\n`;
+                })
+                .join(" ")
+            );
+    } else {
+      //  handles ".md" content
+      htmlBody = data
+        .replace(/\[(.*?)\]\((.*?)\)/gim, "<a href='$2'>$1</a>") // replaces link -> <a href="$2">$1</a>
+        .split(/\r?\n\r?\n/)
+        .map(function (para) {
+          if (para.match(/(?<!#)#{1}\s/)) {
+            return `<h1>${para.replace(/# /, "")}</h1>\n\n`; // replaces # -> <h1></h1>
+          } else if (para.match(/(?<!#)#{2}\s/)) {
+            return `<h2>${para.replace(/## /, "")}</h2>\n\n`; // replace ## -> <h2></h2>
+          }
+          return `<p>${para.replace(/\r?\n/, " ")}</p>\n\n`;
+        })
+        .join(" ");
     }
+
+    const html = createHtml({
+      lang: "en",
+      head: `<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />`,
+      title: htmlTitle ? htmlTitle[0].trim() : filename,
+      css:
+        stylesheetURL != null
+          ? stylesheetURL
+          : "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css",
+      body: htmlBody,
+    });
+
+    await writeFile(
+      path.join(__dirname, "../", "dist", `${filename}.html`),
+      html
+    );
+    console.log(`${filename}.html has been created.`);
+  } catch (err) {
+    console.log(err);
+  }
 }
 
 module.exports = generateHTMLFile;

--- a/utils/processInput.js
+++ b/utils/processInput.js
@@ -11,63 +11,64 @@ const generateHTMLFile = require("./generateHTML");
  * @param {string} inputPath - A path to a file/directory
  */
 async function processInput(inputPath, stylesheetURL) {
-    if (!existsSync(inputPath)) {
-        console.log("File/folder's path does not exist.");
-        return process.exit(1);
-    }
-
-    await manageDist();
-
-    if (statSync(inputPath).isDirectory()) {
-        try {
-            const entries = await readdir(inputPath);
-
-            // Filters out any non-text files
-            const textFiles = entries.filter((entry) => {
-                return (
-                    statSync(path.join(inputPath, entry)).isFile() &&
-                    path.extname(entry) === ".txt"
-                );
-            });
-            textFiles.forEach((file) => {
-                generateHTMLFile(path.join(inputPath, file), stylesheetURL);
-            });
-            return;
-        } catch (err) {
-            console.log(err);
-        }
-    }
-
-    if (path.extname(inputPath) === ".txt") {
-        generateHTMLFile(inputPath, stylesheetURL);
-        return;
-    }
-
-    console.log("File extension must be '.txt'.");
+  if (!existsSync(inputPath)) {
+    console.log("File/folder's path does not exist.");
     return process.exit(1);
+  }
+
+  await manageDist();
+
+  if (statSync(inputPath).isDirectory()) {
+    try {
+      const entries = await readdir(inputPath);
+
+      // Filters out any non-text files
+      const textFiles = entries.filter((entry) => {
+        return (
+          statSync(path.join(inputPath, entry)).isFile() &&
+          (path.extname(entry) === ".txt" || path.extname(entry) === ".md") // adds ".md" extension
+        );
+      });
+      textFiles.forEach((file) => {
+        generateHTMLFile(path.join(inputPath, file), stylesheetURL);
+      });
+      return;
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  // adds ".md" extension
+  if (path.extname(inputPath) === ".txt" || path.extname(inputPath) === ".md") {
+    generateHTMLFile(inputPath, stylesheetURL);
+    return;
+  }
+
+  console.log("File extension must be '.txt' or '.md'.");
+  return process.exit(1);
 }
 
 /**
  * Recursively deletes the existing 'dist' directory and creates a new one.
  */
 async function manageDist() {
-    const distPath = path.join(__dirname, "../", "dist");
+  const distPath = path.join(__dirname, "../", "dist");
 
-    try {
-        await rm(distPath, {
-            recursive: true,
-            force: true,
-        });
-    } catch (err) {
-        // Error is ignored since we are about to create 'dist' anyway.
-    }
+  try {
+    await rm(distPath, {
+      recursive: true,
+      force: true,
+    });
+  } catch (err) {
+    // Error is ignored since we are about to create 'dist' anyway.
+  }
 
-    try {
-        await mkdir(distPath);
-    } catch (err) {
-        console.log("Error creating 'dist' folder.");
-        return process.exit(1);
-    }
+  try {
+    await mkdir(distPath);
+  } catch (err) {
+    console.log("Error creating 'dist' folder.");
+    return process.exit(1);
+  }
 }
 
 module.exports = processInput;


### PR DESCRIPTION
Hi Quan, I have completed the code for the markdown support. 
Here are some changes I had made:

* In `mini-ssg.js`:
  - Modify the file handling so it will accept the ".md" extension. 
  
* In `generateHTML.js`:
  - Render Heading 1.
  - Render Heading 2.
  - Render Link.
 
* In `README.md`:
   - Update README.md to add documentation for Markdown support.

Please review it and let me know If you want me to change any part. 
